### PR TITLE
Update Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -14,6 +14,11 @@ RUN apt-get update && apt-get install -y \
     curl \
     ros-jazzy-rmw-implementation \
     ros-jazzy-rmw-cyclonedds-cpp \
+    ros-jazzy-turtlebot3-gazebo \
+    ros-jazzy-turtlebot3-navigation2 \
+    ros-jazzy-nav2-common \
+    ros-jazzy-navigation2 \
+    ros-jazzy-slam-toolbox \
     && rm -rf /var/lib/apt/lists/*
 
 # Create your CycloneDDS config file


### PR DESCRIPTION
The line 41:
# Install dependencies using rosdep
RUN rosdep install --from-paths src --ignore-src -r -y

did not work, because of some inconsistencies due to ros2 version. The dockerfile would not build the image.
Had to add lines 17 to 21 for it to work.

For me now works, please check it.

P.S. This should resolve the  _rosdep install --from-paths src --ignore-src -r -y_ issue that is open.
